### PR TITLE
Return the bounty address from createBounty.  

### DIFF
--- a/contracts/StandardBountiesFactory.sol
+++ b/contracts/StandardBountiesFactory.sol
@@ -19,12 +19,15 @@ contract StandardBountiesFactory {
 
   function createBounty(address _controller, address _arbiter, string _data, uint _deadline)
   public
+  returns (address)
   {
     address newBounty = new Proxy(masterCopy);
     bounties.push(StandardBounty(newBounty));
     bounties[bounties.length - 1].initializeBounty(_controller, _arbiter, _data, _deadline);
 
     BountyCreated(bounties.length - 1, bounties[bounties.length - 1]);
+
+    return newBounty;
   }
 
   function getNumBounties()


### PR DESCRIPTION
This is useful when interacting with the factory from another smart contract.  Testing is awkward because the function is invoked with a transaction.  I could create a dummy test contract that interacts with the factory and stores the returned value, then evaluate that value in a test, but it seems a bit overkill.  Coverage of the factory is still 100%.